### PR TITLE
Use serve-webpack-client to serve the client in dev and prod modes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "postinstall": "npm run typings; npm run build;",
     "typings": "rimraf typings && tsd install && tsd link",
-    "dev": "NODE_ENV=development webpack-dev-server --display-error-details --display-cached",
+    "dev": "NODE_ENV=development nodemon server.js",
     "start": "NODE_ENV=production node server.js",
     "clean": "rimraf dist",
     "prebuild": "npm run clean",
@@ -43,6 +43,7 @@
     "redux-thunk": "^1.0.0",
     "reflect-metadata": "^0.1.2",
     "rxjs": "^5.0.0-beta.0",
+    "serve-webpack-client": "0.0.4",
     "winston": "^2.1.1",
     "zone.js": "^0.5.10"
   },
@@ -67,6 +68,7 @@
     "karma-sourcemap-loader": "^0.3.6",
     "karma-webpack": "^1.7.0",
     "mocha": "^2.3.3",
+    "nodemon": "^1.8.1",
     "ramda": "^0.18.0",
     "raw-loader": "^0.5.1",
     "rimraf": "^2.4.3",
@@ -79,7 +81,6 @@
     "tslint-loader": "^1.0.2",
     "typescript": "^1.7.3",
     "url-loader": "^0.5.6",
-    "webpack": "^1.12.9",
-    "webpack-dev-server": "^1.14.0"
+    "webpack": "^1.12.9"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,12 +1,17 @@
 const express = require('express');
 const winston = require('winston');
 const chalk = require('chalk');
+const path = require('path');
+const serveWebpackClient = require('serve-webpack-client');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
-const DOMAIN = '0.0.0.0';
 
-app.use('/', express.static('dist'));
+app.use(serveWebpackClient({
+  distPath: path.join(__dirname, 'dist'),
+  indexFileName: 'index.html',
+  webpackConfig: require('./webpack.config')
+}));
 
 app.listen(PORT, (err) => {
   if (err) {
@@ -14,5 +19,5 @@ app.listen(PORT, (err) => {
     return;
   }
 
-  winston.info(`Listening at http://${ chalk.green(DOMAIN) }:${ chalk.yellow(PORT) }`);
+  winston.info(`Listening on port ${ chalk.yellow(PORT) }`);
 });

--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -1,2 +1,3 @@
 /// <reference path="redux-logger/redux-logger.d.ts" />
 /// <reference path="redux/redux.d.ts" />
+/// <reference path="../node_modules/reflect-metadata/reflect-metadata.d.ts" />

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,12 +32,7 @@ const plugins = basePlugins
   .concat(process.env.NODE_ENV === 'development' ? devPlugins : []);
 
 module.exports = {
-  
-  stats: {
-    colors: true,
-    reasons: true
-  },
-  
+
   entry: {
     app: './src/index.ts',
     vendor: [
@@ -55,21 +50,21 @@ module.exports = {
       'redux-logger'
     ]
   },
-  
+
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: '[name].[hash].bundle.js',
+    filename: '[name].[hash].js',
     publicPath: "/",
-    sourceMapFilename: '[name].[hash].bundle.js.map',
+    sourceMapFilename: '[name].[hash].js.map',
     chunkFilename: '[id].chunk.js'
   },
-  
+
   devtool: 'source-map',
-  
+
   resolve: {
     extensions: ['', '.webpack.js', '.web.js', '.ts', '.js']
   },
-  
+
   plugins: plugins,
 
   module: {
@@ -87,12 +82,5 @@ module.exports = {
       { test: /\.woff2/, loader: 'url' },
       { test: /\.ttf/, loader: 'url' },
     ]
-  },
-  
-  devServer: {
-    inline: true,
-    colors: true,
-    contentBase: './dist',
-    publicPath: '/'
   }
 }


### PR DESCRIPTION
This makes sure history api fallback routing works in dev and prod modes, and that we use the minified bundle in prod and the watcher middleware in dev.

Also harmonized the web pack config with recent changes to the other starter projects.